### PR TITLE
Bump shiro-spring from 1.7.0 to 1.7.1 in /spring-boot-shiro

### DIFF
--- a/spring-boot-shiro/pom.xml
+++ b/spring-boot-shiro/pom.xml
@@ -45,7 +45,7 @@
 		<dependency>
 			<groupId>org.apache.shiro</groupId>
 			<artifactId>shiro-spring</artifactId>
-			<version>1.7.0</version>
+			<version>1.7.1</version>
 		</dependency>
 		<dependency>
 			<groupId>mysql</groupId>


### PR DESCRIPTION
Bumps shiro-spring from 1.7.0 to 1.7.1.

---
updated-dependencies:
- dependency-name: org.apache.shiro:shiro-spring dependency-type: direct:production ...

Signed-off-by: dependabot[bot] <support@github.com>